### PR TITLE
Implementing empty critical section check

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -724,12 +724,12 @@ func CheckEmptyCriticalSection(f *lint.File) {
 		if len(block.List) < 2 {
 			return true
 		}
-		for i := range block.List {
+		for i := range block.List[:len(block.List)-1] {
 			if i == len(block.List)-1 {
 				break
 			}
 
-			mutexParams := func(s ast.Stmt) ([]string, string, bool) {
+			mutexParams := func(s ast.Stmt) (selectorTokens []string, funFullName string, ok bool) {
 				expr, ok := s.(*ast.ExprStmt)
 				if !ok {
 					return nil, "", false

--- a/testdata/empty-critical-section.go
+++ b/testdata/empty-critical-section.go
@@ -59,3 +59,20 @@ func fn6() {
 	x.Lock()
 	x.Unlock() // MATCH /empty critical section/
 }
+
+func fn7() {
+	x := &struct {
+		sync.Mutex
+	}{}
+
+	x.Lock()
+	x.Unlock() // MATCH /empty critical section/
+}
+
+func fn8() {
+	var x sync.Locker
+	x = new(sync.Mutex)
+
+	x.Lock()
+	x.Unlock() // MATCH /empty critical section/
+}

--- a/testdata/empty-critical-section.go
+++ b/testdata/empty-critical-section.go
@@ -1,0 +1,55 @@
+package pkg
+
+import "sync"
+
+func fn1() {
+	var x sync.Mutex
+	x.Lock()
+	x.Unlock() // MATCH /empty critical section/
+}
+
+func fn2() {
+	x := struct {
+		m1 struct {
+			m2 sync.Mutex
+		}
+	}{}
+
+	x.m1.m2.Lock()
+	x.m1.m2.Unlock() // MATCH /empty critical section/
+
+}
+
+func fn3() {
+	var x sync.RWMutex
+	x.Lock()
+	x.Unlock() // MATCH /empty critical section/
+
+	x.RLock()
+	x.RUnlock() // MATCH /empty critical section/
+
+	x.Lock()
+	defer x.Unlock()
+}
+
+func fn4() {
+
+	x := struct {
+		m func() *sync.Mutex
+	}{
+		m: func() *sync.Mutex {
+			return new(sync.Mutex)
+		},
+	}
+
+	x.m().Lock()
+	x.m().Unlock()
+}
+
+func fn5() {
+	i := 0
+	var x sync.Mutex
+	x.Lock()
+	i++
+	x.Unlock()
+}

--- a/testdata/empty-critical-section.go
+++ b/testdata/empty-critical-section.go
@@ -53,3 +53,9 @@ func fn5() {
 	i++
 	x.Unlock()
 }
+
+func fn6() {
+	x := &sync.Mutex{}
+	x.Lock()
+	x.Unlock() // MATCH /empty critical section/
+}


### PR DESCRIPTION
@dgryski asked for an empty critical section check. To detect missing defers.

Quoting @dgryski : 
dominikh: idea for a static check (from code pushed to our internal repo):

``` go
func Close() error {
       containersMutex.Lock()
       containersMutex.Unlock()   //  <-- empty critical section, missing defer
       for _, c := range containers {
               c.Close()
       }

       return nil
}
```

It's my first pull request to an open source Go project. So please let me know if there's anything that needs to be modified.
