### PR TITLE
Check for pointer value pointer and related bad copy attempts

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ The following things are currently checked by staticcheck:
 - Checks for empty critical sections, e.g. `(*sync.Mutex).Lock`
   directly followed by `(*sync.Mutex).Unlock`. This usually indicates
   a missing `defer`, or otherwise questionable code.
+- Ineffective use of `&*x` or `*&y` when x is of type `*T` and y is
+  of type `T`.
 
 ## Examples
 

--- a/testdata/ineffective-pointers.go
+++ b/testdata/ineffective-pointers.go
@@ -1,0 +1,11 @@
+package pkg
+
+type T struct{}
+
+func fn1(_ T) {}
+
+func fn2() {
+	t1 := &T{}
+	fn1(&*t1) // MATCH /&*T is ineffective. It will be simplified to T/
+	fn1(*&s1) // MATCH /\*&T is ineffective. It will be simplified to T/
+}


### PR DESCRIPTION
I, and I've seen another case, where attempts have been made to make a copy of a variable, such as a pointer, but doing a `original := &T{}; copy := &*original`, this is usually a mistake.

I've checked the following against ~2000 open source projects but did not find any matches, but also did not find any false positives, so I'm reasonably confident with the tests.

Note, I've called this pointer value pointer, for lack of a better term, more than happy to rename to something more appropriate.
