### PR TITLE
Fix DeferInChannelRangeLoop nil pointer

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -378,7 +378,11 @@ func CheckDubiousDeferInChannelRangeLoop(f *lint.File) {
 		if !ok {
 			return true
 		}
-		_, ok = f.Pkg.TypesInfo.TypeOf(loop.X).Underlying().(*types.Chan)
+		typ := f.Pkg.TypesInfo.TypeOf(loop.X)
+		if typ == nil {
+			return true
+		}
+		_, ok = typ.Underlying().(*types.Chan)
 		if !ok {
 			return true
 		}


### PR DESCRIPTION
There's crash when running `staticcheck -dubious` (version 51fa9d420c249ed508b48dfb6bc5c07b0a043ebd) on github.com/anacrolix/torrent:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x28 pc=0x466f54]

goroutine 1 [running]:
panic(0x747f40, 0xc82000e0b0)
        /usr/local/go/src/runtime/panic.go:481 +0x3e6
honnef.co/go/staticcheck.CheckDubiousDeferInChannelRangeLoop.func1(0x7f50e1f356d8, 0xc820ab6960, 0xc820ac0201)
        /home/bradleyf/scripts/go/src/honnef.co/go/staticcheck/lint.go:381 +0xe4
go/ast.inspector.Visit(0xc820b0c830, 0x7f50e1f356d8, 0xc820ab6960, 0x0, 0x0)
        /usr/local/go/src/go/ast/walk.go:373 +0x40
go/ast.Walk(0x7f50e1f223b8, 0xc820b0c830, 0x7f50e1f356d8, 0xc820ab6960)
        /usr/local/go/src/go/ast/walk.go:52 +0x56
go/ast.walkStmtList(0x7f50e1f223b8, 0xc820b0c830, 0xc820085000, 0x17, 0x20)
        /usr/local/go/src/go/ast/walk.go:32 +0xd5
go/ast.Walk(0x7f50e1f223b8, 0xc820b0c830, 0x7f50e1f224d0, 0xc820ab96e0)
        /usr/local/go/src/go/ast/walk.go:224 +0x3e1e
go/ast.Walk(0x7f50e1f223b8, 0xc820b0c830, 0x7f50e1f22470, 0xc820ab9710)
        /usr/local/go/src/go/ast/walk.go:344 +0xb46
go/ast.walkDeclList(0x7f50e1f223b8, 0xc820b0c830, 0xc820012800, 0x70, 0x80)
        /usr/local/go/src/go/ast/walk.go:38 +0xd5
go/ast.Walk(0x7f50e1f223b8, 0xc820b0c830, 0x7f50e1f21d60, 0xc8203cd500)
        /usr/local/go/src/go/ast/walk.go:353 +0x29b9
go/ast.Inspect(0x7f50e1f21d60, 0xc8203cd500, 0xc820b0c830)
        /usr/local/go/src/go/ast/walk.go:385 +0x60
honnef.co/go/lint.(*File).Walk(0xc820b2e000, 0xc820b0c830)
        /home/bradleyf/scripts/go/src/honnef.co/go/lint/lint.go:336 +0x4c
honnef.co/go/staticcheck.CheckDubiousDeferInChannelRangeLoop(0xc820b2e000)
        /home/bradleyf/scripts/go/src/honnef.co/go/staticcheck/lint.go:405 +0x5c
honnef.co/go/lint.(*Pkg).lintFile(0xc8205dfa80, 0xc820b2e000, 0x962d10, 0x1, 0x1)
        /home/bradleyf/scripts/go/src/honnef.co/go/lint/lint.go:159 +0x60
honnef.co/go/lint.(*Pkg).lint(0xc8205dfa80, 0x962d10, 0x1, 0x1, 0x0, 0x0, 0x0)
        /home/bradleyf/scripts/go/src/honnef.co/go/lint/lint.go:149 +0x119
honnef.co/go/lint.(*Linter).LintFiles(0xc82063d6b8, 0xc82063d750, 0x0, 0x0, 0x0, 0x0, 0x0)
        /home/bradleyf/scripts/go/src/honnef.co/go/lint/lint.go:109 +0x4f4
honnef.co/go/lint/lintutil.(*runner).lintFiles(0xc82063de10, 0xc820074b40, 0x1a, 0x24)
        /home/bradleyf/scripts/go/src/honnef.co/go/lint/lintutil/util.go:114 +0x320
honnef.co/go/lint/lintutil.(*runner).lintImportedPackage(0xc82063de10, 0xc820208380, 0x0, 0x0)
        /home/bradleyf/scripts/go/src/honnef.co/go/lint/lintutil/util.go:162 +0x78b
honnef.co/go/lint/lintutil.(*runner).lintPackage(0xc82063de10, 0x7ad450, 0x1)
        /home/bradleyf/scripts/go/src/honnef.co/go/lint/lintutil/util.go:134 +0xe7
honnef.co/go/lint/lintutil.ProcessArgs(0x7c2350, 0xb, 0x962d10, 0x1, 0x1, 0x0, 0x0, 0x0)
        /home/bradleyf/scripts/go/src/honnef.co/go/lint/lintutil/util.go:90 +0x555
main.main()
        /home/bradleyf/scripts/go/src/honnef.co/go/staticcheck/cmd/staticcheck/staticcheck.go:24 +0x230
```

I didn't also provide failing tests, as I couldn't find enough time to determine a case to reproduce without using the original repository. 

Lines causing crash in torrent.go

```
 248     for _, f := range t.info.UpvertedFiles() {
 249         t.length += f.Length
 250     }
```
