### PR TITLE
Check for return statements before mutex unlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The following things are currently checked by staticcheck:
 | SA2001     | Empty critical section, did you mean to `defer` the unlock?                                                |
 | SA2002     | Called testing.T.FailNow or SkipNow in a goroutine, which isn't allowed                                    |
 | SA2003     | Deferred Lock right after locking, likely meant to defer Unlock instead                                    |
+| SA2004     | Return statement before mutex unlock                                                                       |
 |            |                                                                                                            |
 | **SA3???** | **Testing issues**                                                                                         |
 | SA3000     | TestMain doesn't call os.Exit, hiding test failures                                                        |

--- a/testdata/CheckReturnBeforeMutexUnlock.go
+++ b/testdata/CheckReturnBeforeMutexUnlock.go
@@ -96,9 +96,10 @@ func fn10() {
 	x.Lock()
 	if true {
 		return // MATCH /return before mutex unlock/
-	} else {
+	} else if false {
 		return // MATCH /return before mutex unlock/
 	}
+	x.Unlock()
 }
 
 func fn11() {
@@ -289,4 +290,12 @@ func fn26() {
 		return // MATCH /return before mutex unlock/
 	}
 	x.Unlock()
+}
+
+func fn27() {
+	var x sync.Mutex
+	x.Lock()
+	if true {
+		return
+	}
 }

--- a/testdata/CheckReturnBeforeMutexUnlock.go
+++ b/testdata/CheckReturnBeforeMutexUnlock.go
@@ -1,0 +1,292 @@
+package pkg
+
+import "sync"
+
+func fn1() {
+	var x sync.Mutex
+	x.Lock()
+	if true {
+		return // MATCH /return before mutex unlock/
+	}
+	x.Unlock()
+}
+
+func fn2() {
+	var x, y sync.Mutex
+	x.Lock()
+	if true {
+		return // MATCH /return before mutex unlock/
+	}
+	x.Unlock()
+	y.Lock()
+	if true {
+		return // MATCH /return before mutex unlock/
+	}
+	y.Unlock()
+}
+
+func fn3() {
+	var x sync.Mutex
+	x.Lock()
+}
+
+func fn4() {
+	var x sync.Mutex
+	x.Lock()
+	defer x.Unlock()
+	if true {
+		return
+	}
+}
+
+func fn5() {
+	var x sync.Mutex
+	x.Lock()
+	if true {
+	}
+	x.Unlock()
+	return
+}
+
+func fn6() {
+	var x, y sync.Mutex
+	y.Lock()
+	x.Lock()
+	y.Unlock()
+	if true {
+		return // MATCH /return before mutex unlock/
+	}
+	x.Unlock()
+}
+
+func fn7() {
+	x := &struct {
+		sync.Mutex
+	}{}
+
+	x.Lock()
+	if true {
+		return // MATCH /return before mutex unlock/
+	}
+	x.Unlock()
+}
+
+func fn8() {
+	var x sync.Mutex
+	x.Lock()
+	defer func() {
+		x.Unlock()
+	}()
+	return
+}
+
+func fn9() {
+	var x sync.Mutex
+	x.Lock()
+	if true {
+
+	} else {
+		return // MATCH /return before mutex unlock/
+	}
+	x.Unlock()
+}
+
+func fn10() {
+	var x sync.Mutex
+	x.Lock()
+	if true {
+		return // MATCH /return before mutex unlock/
+	} else {
+		return // MATCH /return before mutex unlock/
+	}
+}
+
+func fn11() {
+	type X struct {
+		mu sync.Mutex
+	}
+	var x X
+	x.mu.Lock()
+	if true {
+		return // MATCH /return before mutex unlock/
+	}
+	x.mu.Unlock()
+}
+
+func fn12() {
+	type X struct {
+		mu sync.Mutex
+	}
+	var x X
+	x.mu.Lock()
+	mu := &x.mu
+	mu.Unlock()
+	if true {
+		return
+	}
+}
+
+func fn13() {
+	var x sync.Mutex
+	x.Lock()
+	y := &x
+	y.Unlock()
+	if true {
+		return
+	}
+}
+
+func fn14() {
+	var x, y sync.Mutex
+	x.Lock()
+	y.Unlock()
+	if true {
+		return // false negative
+	}
+}
+
+func fn15() { //
+	var x, y sync.Mutex
+	x.Lock()
+	defer x.Unlock()
+
+	x.Unlock()
+
+	y.Lock()
+	defer y.Unlock()
+
+	x.Lock()
+	return
+}
+
+func fn16() {
+	fn := func() {
+		var x sync.Mutex
+		x.Lock()
+		if true {
+			return // MATCH /return before mutex unlock/
+		}
+		x.Unlock()
+	}
+	fn()
+}
+
+func fn17() {
+	x := struct {
+		m1 struct {
+			m2 sync.Mutex
+		}
+	}{}
+
+	x.m1.m2.Lock()
+	if true {
+		return // MATCH /return before mutex unlock/
+	}
+	x.m1.m2.Unlock()
+}
+
+func fn18() {
+	var x sync.RWMutex
+	x.Lock()
+	if true {
+		return // MATCH /return before mutex unlock/
+	}
+	x.Unlock()
+
+	x.RLock()
+	if true {
+		return // MATCH /return before mutex unlock/
+	}
+	x.RUnlock()
+}
+
+func fn19() {
+	x := struct {
+		m func() *sync.Mutex
+	}{
+		m: func() *sync.Mutex {
+			return new(sync.Mutex)
+		},
+	}
+
+	x.m().Lock()
+	if true {
+		return // MATCH /return before mutex unlock/
+	}
+	x.m().Unlock()
+}
+
+func fn20() {
+	x := &sync.Mutex{}
+	x.Lock()
+	if true {
+		return // MATCH /return before mutex unlock/
+	}
+	x.Unlock()
+}
+
+func fn21() {
+	x := &struct {
+		sync.Mutex
+	}{}
+
+	x.Lock()
+	if true {
+		return // MATCH /return before mutex unlock/
+	}
+	x.Unlock()
+}
+
+func fn22() {
+	var x sync.Locker
+	x = new(sync.Mutex)
+
+	x.Lock()
+	if true {
+		return // MATCH /return before mutex unlock/
+	}
+	x.Unlock()
+}
+
+func fn23() {
+	var x sync.Mutex
+	x.Lock()
+	if true {
+		return // MATCH /return before mutex unlock/
+	}
+	func() {
+		x.Unlock()
+	}()
+}
+
+func fn24() {
+	var x sync.Mutex
+	x.Lock()
+	switch "word" {
+	case "word":
+		return // MATCH /return before mutex unlock/
+	}
+	x.Unlock()
+}
+
+func fn25() {
+	var x sync.Mutex
+	fn := func() {
+		x.Unlock()
+	}
+	defer fn()
+	x.Lock()
+	if true {
+		return
+	}
+}
+
+func fn26() {
+	var m map[string]int
+	var x sync.Mutex
+	x.Lock()
+	if _, ok := m["value"]; ok {
+		return // MATCH /return before mutex unlock/
+	}
+	x.Unlock()
+}


### PR DESCRIPTION
This check aims to catch errors where a mutex is locked and the function can return before unlocking.

```go
var (
       cacheMu sync.RWMutex
       cache = make(map[string]string)
)

func retrieveItem(key string) string {
       cacheMu.Lock()
       if item, ok := cache[key]; ok {
              return item  // mutex not unlocked
       }
       cacheMu.Unlock()

       // ...retrieve item due to cache miss...
}
```

To avoid false positives where someone may be wrapping a mutex, this check does not warn when the function does not contain an `Unlock` call.

This is my first time working with the ast package. If there is a better way of implementing this check I'd be happy to rework the PR.