### PR TITLE
WIP: Check for sufficient channel buffer size for signals being trapped

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The following things are currently checked by staticcheck:
 | SA1013     | `io.Seeker.Seek` is being called with the `whence` constant as the first argument, but it should be the second |
 | SA1014     | Non-pointer value passed to Unmarshal or Decode                                                                |
 | SA1015     | Trapping a signal that cannot be trapped                                                                       |
+| SA1016     | Sufficient channel buffer size for signals being trapped                                                       |
 |            |                                                                                                                |
 | **SA2???** | **Concurrency issues**                                                                                         |
 | SA2000     | `sync.WaitGroup.Add` called inside the goroutine, leading to a race condition                                  |

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The following things are currently checked by staticcheck:
 | SA1012     | A nil `context.Context` is being passed to a function, consider using context.TODO instead                     |
 | SA1013     | `io.Seeker.Seek` is being called with the `whence` constant as the first argument, but it should be the second |
 | SA1014     | Non-pointer value passed to Unmarshal or Decode                                                                |
+| SA1015     | Trapping a signal that cannot be trapped                                                                       |
 |            |                                                                                                                |
 | **SA2???** | **Concurrency issues**                                                                                         |
 | SA2000     | `sync.WaitGroup.Add` called inside the goroutine, leading to a race condition                                  |

--- a/lint.go
+++ b/lint.go
@@ -40,6 +40,7 @@ var Funcs = map[string]lint.Func{
 	"SA1013": CheckSeeker,
 	"SA1014": CheckUnmarshalPointer,
 	"SA1015": CheckUntrappableSignal,
+	"SA1016": CheckSignalChannelSize,
 
 	"SA2000": CheckWaitgroupAdd,
 	"SA2001": CheckEmptyCriticalSection,
@@ -90,6 +91,69 @@ func constantString(f *lint.File, expr ast.Expr) (string, bool) {
 
 func hasType(f *lint.File, expr ast.Expr, name string) bool {
 	return types.TypeString(f.Pkg.TypesInfo.TypeOf(expr), nil) == name
+}
+
+func CheckSignalChannelSize(f *lint.File) {
+	fn := func(node ast.Node) bool {
+		// track channel positions and their sizes
+		chanPosSize := make(map[token.Pos]int)
+
+		// find channels of type os.Signal and track their buffer size
+		fn2 := func(node ast.Node) bool {
+			asn, ok := node.(*ast.AssignStmt)
+			if !ok {
+				return true
+			}
+			for i, rhs := range asn.Rhs {
+				call, ok := rhs.(*ast.CallExpr)
+				if !ok {
+					continue
+				}
+				if fn, ok := call.Fun.(*ast.Ident); !ok || fn.Name != "make" {
+					continue
+				}
+				buffSize := 0
+				if len(call.Args) == 2 {
+					if buffSize, ok = constantInt(f, call.Args[1]); !ok {
+						continue
+					}
+				}
+				chanPosSize[asn.Lhs[i].Pos()] = buffSize
+			}
+
+			return false // Don't recurse into make calls
+		}
+		ast.Inspect(node, fn2)
+
+		// Find all calls to signal.Notify and check their channel's size
+		fn3 := func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			if !lint.IsPkgDot(call.Fun, "signal", "Notify") {
+				return true
+			}
+			chn, ok := call.Args[0].(*ast.Ident)
+			if !ok {
+				return false
+			}
+			obj := f.Pkg.TypesInfo.ObjectOf(chn)
+			if obj == nil {
+				return true
+			}
+			if buffSize, ok := chanPosSize[obj.Pos()]; ok {
+				if buffSize < len(call.Args)-1 {
+					f.Errorf(chn, "channel buffer size %d is too small to catch %v signal(s)", buffSize, len(call.Args)-1)
+				}
+			}
+			return false // don't recurse into signal.* calls
+		}
+		ast.Inspect(node, fn3)
+
+		return false // fn2/fn3 have already recursed
+	}
+	f.Walk(fn)
 }
 
 func CheckUntrappableSignal(f *lint.File) {

--- a/lint.go
+++ b/lint.go
@@ -103,11 +103,17 @@ func CheckUntrappableSignal(f *lint.File) {
 			!lint.IsPkgDot(call.Fun, "signal", "Reset") {
 			return true
 		}
-		for _, arg := range call.Args {
-			if lint.IsPkgDot(arg, "os", "Kill") ||
-				lint.IsPkgDot(arg, "syscall", "SIGKILL") ||
-				lint.IsPkgDot(arg, "syscall", "SIGSTOP") {
-				f.Errorf(arg, "signal cannot be trapped")
+		for _, callArg := range call.Args {
+			arg := callArg
+			if isTypeName(f, arg, "os", "Signal") && len(arg.(*ast.CallExpr).Args) == 1 {
+				arg = arg.(*ast.CallExpr).Args[0]
+			}
+
+			switch {
+			case lint.IsPkgDot(arg, "os", "Kill"), lint.IsPkgDot(arg, "syscall", "SIGKILL"):
+				f.Errorf(arg, "SIGKILL signal cannot be trapped (did you mean syscall.SIGTERM?)")
+			case lint.IsPkgDot(arg, "syscall", "SIGSTOP"):
+				f.Errorf(arg, "SIGSTOP signal cannot be trapped")
 			}
 		}
 		return true
@@ -2093,6 +2099,19 @@ func CheckInfiniteRecursion(f *lint.File) {
 		return true
 	}
 	f.Walk(fn)
+}
+
+func isTypeName(f *lint.File, node ast.Node, pkgName, name string) bool {
+	call, ok := node.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	tn, ok := f.Pkg.TypesInfo.ObjectOf(sel.Sel).(*types.TypeName)
+	return ok && tn.Pkg().Name() == pkgName && tn.Name() == name
 }
 
 func isFunctionCallName(f *lint.File, node ast.Node, name string) bool {

--- a/testdata/CheckSignalChannelSize.go
+++ b/testdata/CheckSignalChannelSize.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func fn() {
+	c0 := make(chan os.Signal)
+	signal.Notify(c0, os.Interrupt) // MATCH /channel buffer size 0 is too small to catch 1 signal/
+
+	c1 := make(chan os.Signal, 1)
+	signal.Notify(c1, os.Interrupt, syscall.SIGHUP) // MATCH /channel buffer size 1 is too small to catch 2 signal/
+
+	c2 := make(chan os.Signal, 1)
+	signal.Notify(c2, os.Interrupt)
+	signal.Notify(c2, syscall.SIGHUP) // MATCH /channel buffer size 1 is too small to catch 2 signal/
+}

--- a/testdata/CheckUntrappableSignal.go
+++ b/testdata/CheckUntrappableSignal.go
@@ -9,13 +9,14 @@ import (
 func fn() {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
-	signal.Ignore(os.Kill)            // MATCH /signal cannot be trapped/
-	signal.Notify(c, os.Kill)         // MATCH /signal cannot be trapped/
-	signal.Reset(os.Kill)             // MATCH /signal cannot be trapped/
-	signal.Ignore(syscall.SIGKILL)    // MATCH /signal cannot be trapped/
-	signal.Notify(c, syscall.SIGKILL) // MATCH /signal cannot be trapped/
-	signal.Reset(syscall.SIGKILL)     // MATCH /signal cannot be trapped/
-	signal.Ignore(syscall.SIGSTOP)    // MATCH /signal cannot be trapped/
-	signal.Notify(c, syscall.SIGSTOP) // MATCH /signal cannot be trapped/
-	signal.Reset(syscall.SIGSTOP)     // MATCH /signal cannot be trapped/
+	signal.Ignore(os.Signal(syscall.SIGKILL)) // MATCH /signal cannot be trapped/
+	signal.Ignore(os.Kill)                    // MATCH /signal cannot be trapped/
+	signal.Notify(c, os.Kill)                 // MATCH /signal cannot be trapped/
+	signal.Reset(os.Kill)                     // MATCH /signal cannot be trapped/
+	signal.Ignore(syscall.SIGKILL)            // MATCH /signal cannot be trapped/
+	signal.Notify(c, syscall.SIGKILL)         // MATCH /signal cannot be trapped/
+	signal.Reset(syscall.SIGKILL)             // MATCH /signal cannot be trapped/
+	signal.Ignore(syscall.SIGSTOP)            // MATCH /signal cannot be trapped/
+	signal.Notify(c, syscall.SIGSTOP)         // MATCH /signal cannot be trapped/
+	signal.Reset(syscall.SIGSTOP)             // MATCH /signal cannot be trapped/
 }

--- a/testdata/CheckUntrappableSignal.go
+++ b/testdata/CheckUntrappableSignal.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func fn() {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	signal.Ignore(os.Kill)            // MATCH /signal cannot be trapped/
+	signal.Notify(c, os.Kill)         // MATCH /signal cannot be trapped/
+	signal.Reset(os.Kill)             // MATCH /signal cannot be trapped/
+	signal.Ignore(syscall.SIGKILL)    // MATCH /signal cannot be trapped/
+	signal.Notify(c, syscall.SIGKILL) // MATCH /signal cannot be trapped/
+	signal.Reset(syscall.SIGKILL)     // MATCH /signal cannot be trapped/
+	signal.Ignore(syscall.SIGSTOP)    // MATCH /signal cannot be trapped/
+	signal.Notify(c, syscall.SIGSTOP) // MATCH /signal cannot be trapped/
+	signal.Reset(syscall.SIGSTOP)     // MATCH /signal cannot be trapped/
+}


### PR DESCRIPTION
I'm concerned about the actual implementation itself, I'm not certain whether this is the most optimal.

The check currently ensures the buffer size == number of signals caught, however, in discussions with @judwhite and re-reading docs, I also believe just a check the channel is buffered is enough. As the buffer size above 1 depends on the signal rate, not the number of signals.

A test still fails until we can agree whether the check should only check for a buffered channel, or whether it should check the buffer size is at least number of signals being trapped.

Fixes #30 